### PR TITLE
Pass maxBuffer: Infinity to execFileSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 module.exports = function(url) {
   return require('child_process')
-    .execFileSync('curl', ['--silent', '-L', url], {encoding: 'utf8'});
+    .execFileSync('curl', ['--silent', '-L', url], {encoding: 'utf8', maxBuffer: Infinity});
 }


### PR DESCRIPTION
We previously failed to download files over 1 MiB:

    > require("download-file-sync")("https://registry.npmjs.org/webpack")
    Thrown:
    Error: spawnSync curl ENOBUFS
        at Object.spawnSync (internal/child_process.js:1041:20)
        at spawnSync (child_process.js:607:24)
        at Object.execFileSync (child_process.js:634:15)
        at module.exports (/tmp/t/node_modules/download-file-sync/index.js:3:6) {
      errno: 'ENOBUFS',
      code: 'ENOBUFS',
      syscall: 'spawnSync curl',
      path: 'curl',
      spawnargs: [ '--silent', '-L', 'https://registry.npmjs.org/webpack' ],
      error: [Circular],
      status: null,
      signal: 'SIGTERM',
      output: [
        null,
        `{"_id":"webpack","_rev":"1622-78494259e0d0cd5c8a907186d5c82ae5","name":"webpack",[…]`,
        ''
      ],
      pid: 5901,
      stdout: `{"_id":"webpack","_rev":"1622-78494259e0d0cd5c8a907186d5c82ae5","name":"webpack",[…]`,
      stderr: ''
    }